### PR TITLE
fix broken "make install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,4 +283,4 @@ ENDIF()
 # =========================================================================
 # Install
 # =========================================================================
-INSTALL(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/configuration.cmake ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/userblock.txt DESTINATION bin)
+INSTALL(FILES ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/configuration.cmake DESTINATION bin)


### PR DESCRIPTION
userblock.txt is no longer generated, so do not try to install it.

Otherwise, errors like this occur:

Install the project...
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "Release"
-- Installing: /opt/spack/linux-archrolling-haswell/gcc-13.2.1/flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/lib/libflexi.so
-- Set runtime path of "/opt/spack/linux-archrolling-haswell/gcc-13.2.1/flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/lib/libflexi.so" to "/opt/spack/linux-archrolling-haswell/gcc-13.2.1/flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/flex
i-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/lib64:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/hdf5-1.14.2-dxnh6x5jl2z2ifrfryr6fqs6ulniaomc/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/openmpi-4.1.5-t5seoi2cz73ywa2skyxm3c4pike4m7jh/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2
.1/hwloc-2.9.1-3jf7jzpreimbaqx3zz3n73r5lmmtj46n/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/libpciaccess-0.17-b2an7324347nat7675fgnzkje7huz3q2/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/libxml2-2.10.3-oaf6rsne5ija7yex7gn4xncz5tot5dho/lib:/scratch/spack/linux-archrolling-h
aswell/gcc-13.2.1/libiconv-1.17-b7qfizfr7btcrs2zjayddun7v6usnyhx/lib:/scratch/spack/linux-archrolling-haswell/gcc-13.2.1/xz-5.4.1-jzmkn5stxjkwaar2z4bpba4qdthvjrmf/lib:/scratch/spack/linux-archrolling-haswell/gcc-13.2.1/zlib-ng-2.1.3-p42ebsepbbxuekpfj43bxdir6lqf625l/lib:/opt/spack/linux-ar
chrolling-haswell/gcc-13.2.1/ncurses-6.4-4qgwzbph3jecimcwtuumec6huatw65qq/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/pmix-5.0.1-uyfnpmpjflnlbdp54m6amh5pvnd7qezl/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/libevent-2.1.12-if44fzxjjcvvinhgg4jh2jeh5otdaotz/lib:/opt/spack/lin
ux-archrolling-haswell/gcc-13.2.1/openblas-0.3.24-lr32xr2xn57tayebnfsrefic6nevthlh/lib:/opt/spack/linux-archrolling-haswell/gcc-13.2.1/openssl-3.1.3-heiyafb3ikk5cqgpdj37rxrcc7jl7vwf/lib64"
-- Installing: /opt/spack/linux-archrolling-haswell/gcc-13.2.1/flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/bin/flexi
-- Installing: /opt/spack/linux-archrolling-haswell/gcc-13.2.1/flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/bin/configuration.cmake
CMake Error at cmake_install.cmake:73 (file):
  file INSTALL cannot find
  "/tmp/ma/spack-stage/spack-stage-flexi-master-5ml2uwfwqg2lsx3xgakujv3nmbnasi7b/spack-build-5ml2uwf/bin/userblock.txt":
  No such file or directory.
